### PR TITLE
Run PEP8 on content

### DIFF
--- a/azure_deployment.py
+++ b/azure_deployment.py
@@ -12,9 +12,12 @@ from azure.profiles import KnownProfiles
 # AZURE_RESOURCE_LOCATION: with your azure stack resource location
 # this example assumes your ssh public key present here: ~/id_rsa.pub
 
-my_subscription_id = os.environ.get('AZURE_SUBSCRIPTION_ID')   # your Azure Subscription Id
-my_resource_group = 'azure-python-deployment-sample'            # the resource group for deployment
-my_pub_ssh_key_path = os.path.expanduser('~/id_rsa.pub')   # the path to your rsa public key file
+my_subscription_id = os.environ.get(
+    'AZURE_SUBSCRIPTION_ID')   # your Azure Subscription Id
+# the resource group for deployment
+my_resource_group = 'azure-python-deployment-sample'
+# the path to your rsa public key file
+my_pub_ssh_key_path = os.path.expanduser('~/id_rsa.pub')
 
 # Set Azure stack supported API profile as the default profile
 KnownProfiles.default.use(KnownProfiles.v2018_03_01_hybrid)
@@ -31,7 +34,8 @@ print("Beginning the deployment... \n\n")
 # Deploy the template
 my_deployment = deployer.deploy()
 
-print("Done deploying!!\n\nYou can connect via: `ssh azureSample@{}.local.cloudapp.azurestack.external`".format(deployer.dns_label_prefix))
+print("Done deploying!!\n\nYou can connect via: `ssh azureSample@{}.local.cloudapp.azurestack.external`".format(
+    deployer.dns_label_prefix))
 
 # Destroy the resource group which contains the deployment
 # deployer.destroy()

--- a/deployer.py
+++ b/deployer.py
@@ -7,6 +7,7 @@ from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
 from msrestazure.azure_cloud import get_cloud_from_metadata_endpoint
 
+
 class Deployer(object):
     """ Initialize the deployer class with subscription, resource group and public key.
 
@@ -26,7 +27,7 @@ class Deployer(object):
             tenant=os.environ['AZURE_TENANT_ID'],
             cloud_environment=mystack_cloud
         )
-       
+
         self.subscription_id = subscription_id
         self.resource_group = resource_group
         self.dns_label_prefix = self.name_generator.haikunate()
@@ -38,7 +39,7 @@ class Deployer(object):
 
         self.credentials = credentials
         self.client = ResourceManagementClient(self.credentials, self.subscription_id,
-            base_url=mystack_cloud.endpoints.resource_manager)
+                                               base_url=mystack_cloud.endpoints.resource_manager)
 
     def deploy(self):
         """Deploy the template to a resource group."""
@@ -49,7 +50,8 @@ class Deployer(object):
             }
         )
 
-        template_path = os.path.join(os.path.dirname(__file__), 'templates', 'template.json')
+        template_path = os.path.join(os.path.dirname(
+            __file__), 'templates', 'template.json')
         with open(template_path, 'r') as template_file_fd:
             template = json.load(template_file_fd)
 


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.