### PR TITLE
Update readme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-azure-mgmt-resource~=2.0.0rc1
+azure-identity
+azure-mgmt-resource>=20.0.0
 haikunator


### PR DESCRIPTION
Many breaking changes are caused by the migration from track1 to track2 So update the document.

such as:

- LRO operations are renamed to begin_xxx_xxx, for example in track1, the name is delete; while in track2, the name is begin_delete.
- DefaultAzureCredential replaces AADTokenCredentials
- Some operation name or model name changes